### PR TITLE
[style] #2 - game room view 반응형 디자인 적용

### DIFF
--- a/src/pages/gameroom/Canvas.jsx
+++ b/src/pages/gameroom/Canvas.jsx
@@ -163,13 +163,15 @@ const Canvas = ({ isQuizMaster, answer, timePercent }) => {
             disabled={history.length === 0}
             className={styles.toolButton}
           >
-            ↩️ 되돌리기
+            <span className={styles.buttonIcon}>↩️</span>
+            <span className={styles.buttonText}>되돌리기</span>
           </button>
           <button 
             onClick={handleClear}
             className={styles.toolButton}
           >
-            🗑️ 지우기
+            <span className={styles.buttonIcon}>🗑️</span>
+            <span className={styles.buttonText}>지우기</span>
           </button>
         </div>
       </div>

--- a/src/pages/gameroom/Canvas.module.css
+++ b/src/pages/gameroom/Canvas.module.css
@@ -96,6 +96,59 @@
   cursor: pointer;
   font-size: 14px;
   transition: all 0.2s;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  white-space: nowrap;
+}
+
+.buttonIcon {
+  font-size: 16px;
+}
+
+.buttonText {
+  font-size: 14px;
+}
+
+/* 작은 화면에서 텍스트 숨기기 */
+@media (max-width: 1024px) {
+  .lineWidthDisplay {
+    display: none;
+  }
+  
+  .rangeInput {
+    width: 60px;
+  }
+  
+  .buttonText {
+    display: none;
+  }
+  
+  .toolButton {
+    padding: 8px 12px;
+    min-width: 40px;
+    justify-content: center;
+  }
+}
+
+/* 매우 작은 화면에서 더 작게 */
+@media (max-width: 768px) {
+  .rangeInput {
+    width: 50px;
+  }
+  
+  .toolGroup {
+    gap: 16px;
+  }
+  
+  .toolButton {
+    padding: 6px 10px;
+    min-width: 36px;
+  }
+  
+  .buttonIcon {
+    font-size: 14px;
+  }
 }
 
 .toolButton:hover {

--- a/src/pages/gameroom/GameRoom.module.css
+++ b/src/pages/gameroom/GameRoom.module.css
@@ -100,6 +100,50 @@
   flex-direction: column;
   padding: 0;
 }
+
+/* 반응형 유저 리스트 너비 */
+@media (max-width: 1024px) {
+  .leftSection {
+    width: 240px;
+    min-width: 240px;
+  }
+  
+  .logo {
+    width: 240px;
+  }
+}
+
+@media (max-width: 768px) {
+  .leftSection {
+    width: 200px;
+    min-width: 200px;
+  }
+  
+  .logo {
+    width: 200px;
+  }
+  
+  .gameRoom {
+    padding: 16px 24px;
+  }
+}
+
+@media (max-width: 480px) {
+  .leftSection {
+    width: 160px;
+    min-width: 160px;
+  }
+  
+  .logo {
+    width: 160px;
+  }
+  
+  .gameRoom {
+    padding: 12px 16px;
+    gap: 16px;
+  }
+}
+
 .rightSection {
   flex: 1;
   display: flex;

--- a/src/pages/gameroom/PlayerList.module.css
+++ b/src/pages/gameroom/PlayerList.module.css
@@ -5,21 +5,21 @@
   border-radius: 16px;
   display: flex;
   flex-direction: column;
-  justify-content: stretch;
   padding: 0;
   overflow: hidden;
 }
 .playerItem {
   display: flex;
   align-items: center;
-  flex: 1 1 0;
-  min-height: 80px;
+  flex: 1;
+  height: calc(100% / 6);
   border-bottom: 1px solid #dde7ff;
-  padding: 16px;
+  padding: 12px 16px;
   gap: 16px;
   background: transparent;
   transition: all 0.3s ease;
   position: relative;
+  box-sizing: border-box;
 }
 .playerItem.drawing {
   background: rgba(25, 118, 210, 0.1);
@@ -93,4 +93,73 @@
 .placeholder .nickname,
 .placeholder .score {
   color: #bbb;
+}
+
+/* 반응형 유저 리스트 */
+@media (max-width: 1024px) {
+  .playerItem {
+    padding: 10px 12px;
+    gap: 12px;
+  }
+  
+  .avatar, .emptyAvatar {
+    width: 40px;
+    height: 40px;
+  }
+  
+  .nickname {
+    font-size: 1rem;
+  }
+  
+  .score {
+    font-size: 0.9rem;
+  }
+}
+
+@media (max-width: 768px) {
+  .playerItem {
+    padding: 8px 10px;
+    gap: 10px;
+  }
+  
+  .avatar, .emptyAvatar {
+    width: 36px;
+    height: 36px;
+  }
+  
+  .nickname {
+    font-size: 0.9rem;
+  }
+  
+  .score {
+    font-size: 0.85rem;
+  }
+  
+  .drawingIndicator {
+    font-size: 14px;
+  }
+}
+
+@media (max-width: 480px) {
+  .playerItem {
+    padding: 6px 8px;
+    gap: 8px;
+  }
+  
+  .avatar, .emptyAvatar {
+    width: 32px;
+    height: 32px;
+  }
+  
+  .nickname {
+    font-size: 0.85rem;
+  }
+  
+  .score {
+    font-size: 0.8rem;
+  }
+  
+  .drawingIndicator {
+    font-size: 12px;
+  }
 } 


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

#2 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 사용자 리스트 항상 6명사이즈로 꽉차게 변경
- 사용자 리스트 가로 너비 반응형 디자인 적용
- 캔버스 도구 부분 (두께 설정 바, px 표시, 되돌리기, 전부 지우기 버튼) 반응형 디자인 적용

### 스크린샷 (선택)
- 찐 전체 화면
<img width="1710" alt="image" src="https://github.com/user-attachments/assets/b4d06e3c-7588-4dc7-ac28-ec3fa67609f5" />

- 크롬 전체 화면 

<img width="1710" alt="image" src="https://github.com/user-attachments/assets/8e382289-7939-4e85-9d81-173e9d714723" />


-  절반 화면
<img width="856" alt="image" src="https://github.com/user-attachments/assets/6878aba9-3313-484e-906f-dd1ef1b686b2" />

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## 📌 PR 확인 시, Reviewer 체크 사항
- [x] 요구사항 반영 되었는지
- [x] 전체화면, 절반 화면 잘 적용되었는지
- [x] App.css, App.js, index.css, index.js 파일을 수정하지는 않았는지
- [x] 폴더 구조 잘 지켜졌는지
